### PR TITLE
Fix "to_send" argument type on partial sends

### DIFF
--- a/sendfile.scm
+++ b/sendfile.scm
@@ -202,7 +202,7 @@
                 ((negative? new-offset)
                  (complain #t "sendfile failed"))
                 (else
-                 (loop new-offset target-offset)))))))))
+                 (loop (inexact->exact (truncate new-offset)) target-offset)))))))))
   (else
    (define (impl:sendfile . args)
      (complain #f "Sendfile is not available on your system"))))


### PR DESCRIPTION
On the second iteration of the loop, offset becomes new-offset, which is a double. This breaks the C API, which expects `to_send` to be an integer.